### PR TITLE
[FIX] Use resp.get() to prevent KeyError

### DIFF
--- a/odooly.py
+++ b/odooly.py
@@ -383,7 +383,7 @@ def dispatch_jsonrpc(url, service_name, method, args):
     resp = http_post(url, json.dumps(data).encode('ascii'))
     if resp.get('error'):
         raise ServerError(resp['error'])
-    return resp['result']
+    return resp.get('result')
 
 
 class partial(functools.partial):


### PR DESCRIPTION
Whenever a JSON RPC call returns `None`, the `result` key in the response will not exist, and therefore it will trigger a KeyError. By using get(), None is returned if the the 'result' key does not exist.

Fixes #8